### PR TITLE
feat: launch in testnet; improve shutdown functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "main": "public/electron.js",
   "homepage": "./",
-  "version": "1.1.0",
+  "version": "1.0.0-alpha.1",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { Provider } from "mobx-react";
 import React, { ReactElement } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { isWindows } from "./common/appUtil";
-import { OPENDEX_DOCKER_LOCAL_MAINNET_URL } from "./constants";
+import { OPENDEX_DOCKER_LOCAL_TESTNET_URL } from "./constants";
 import Dashboard from "./dashboard/Dashboard";
 import { Path } from "./router/Path";
 import ConnectToRemote from "./setup/ConnectToRemote";
@@ -59,7 +59,8 @@ const GlobalCss = withStyles((theme: Theme) => {
 })(() => null);
 
 const settingsStore = useSettingsStore({
-  opendexDockerUrl: OPENDEX_DOCKER_LOCAL_MAINNET_URL,
+  // TODO: change to mainnet
+  opendexDockerUrl: OPENDEX_DOCKER_LOCAL_TESTNET_URL,
 });
 
 const dockerStore = useDockerStore({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,4 @@ export const OPENDEX_DOCKER_DOCS_URL =
   "https://opendex.network/docs/start-earning/market-maker-guide";
 
 export const OPENDEX_DOCKER_LOCAL_MAINNET_URL = "https://localhost:8889";
+export const OPENDEX_DOCKER_LOCAL_TESTNET_URL = "https://localhost:18889";

--- a/src/setup/Landing.tsx
+++ b/src/setup/Landing.tsx
@@ -35,8 +35,8 @@ const createItems = (envExists?: boolean): Item[] => [
   {
     title: envExists ? "Start" : "Create",
     additionalInfo: envExists
-      ? "OpenDEX environment detected"
-      : "Create new OpenDEX environment",
+      ? "OpenDEX testnet environment detected" // TODO: remove 'testnet'
+      : "Create new OpenDEX testnet environment", // TODO: remove 'testnet'
     icon: envExists ? PlayArrowTwoToneIcon : AddCircleTwoToneIcon,
     path: Path.START_ENVIRONMENT,
   },

--- a/src/setup/create/StartingOpendex.tsx
+++ b/src/setup/create/StartingOpendex.tsx
@@ -13,7 +13,7 @@ import { catchError, mergeMap, take, takeUntil } from "rxjs/operators";
 import api from "../../api";
 import { logError, logInfo } from "../../common/appUtil";
 import { startOpendexDocker$ } from "../../common/dockerUtil";
-import { OPENDEX_DOCKER_LOCAL_MAINNET_URL } from "../../constants";
+import { OPENDEX_DOCKER_LOCAL_TESTNET_URL } from "../../constants";
 import { ConnectionType } from "../../enums";
 import { Path } from "../../router/Path";
 import { SETTINGS_STORE } from "../../stores/settingsStore";
@@ -43,7 +43,8 @@ const StartingOpendex = inject(SETTINGS_STORE)(
     }, []);
 
     useEffect(() => {
-      settingsStore!.setOpendexDockerUrl(OPENDEX_DOCKER_LOCAL_MAINNET_URL);
+      // TODO: change to mainnet
+      settingsStore!.setOpendexDockerUrl(OPENDEX_DOCKER_LOCAL_TESTNET_URL);
       const apiResponsive$ = interval(1000).pipe(
         mergeMap(() => api.setupStatus$(settingsStore!.opendexDockerUrl)),
         catchError((e, caught) => caught),
@@ -68,6 +69,7 @@ const StartingOpendex = inject(SETTINGS_STORE)(
           },
           complete: () => {
             setProgress(100);
+            (window as any).electron.send("set-environment-started", [true]);
             settingsStore!.setConnectionType(ConnectionType.LOCAL);
             setTimeout(() => setShowContent(false), 500);
             setTimeout(() => history.push(Path.DASHBOARD), 1000);


### PR DESCRIPTION
This PR adds the temporary functionality of launching the `testnet` environment instead of `mainnet` on Windows. Once the `mainnet` is ready to be launched, the changes that enable testnet will be reverted.

This PR also improves the shutdown functionality and therefore closes https://github.com/opendexnetwork/opendex-desktop/issues/14.