### PR TITLE
feat: use 21.02.11-rc.2 branch of opendex-docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,12 @@ Application data is stored in the following locations
 
 ### Building Windows executable under Linux
 
-For Debian based distributions
-
+For Debian based distributions you'll need additional dependencies
 ```bash
 sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install wine wine32
+```
+
+To build
+```bash
 yarn build --win
 ```

--- a/README.md
+++ b/README.md
@@ -68,3 +68,12 @@ Application data is stored in the following locations
 ## Building an executable
 
 `yarn build` to build for an OS the command is executed from.
+
+### Building Windows executable under Linux
+
+For Debian based distributions
+
+```bash
+sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install wine wine32
+yarn build --win
+```

--- a/public/ipc.js
+++ b/public/ipc.js
@@ -36,8 +36,9 @@ const AVAILABLE_COMMANDS = {
   modify_docker_settings: "settings modify",
   wsl_version: "wsl --set-default-version 2",
   start_docker: `"${WINDOWS_DOCKER_EXECUTABLE_PATH}"`,
-  setup_opendex_docker: `${LAUNCHER} setup`,
-  stop_opendex_docker: `${LAUNCHER} down`,
+  // TODO: windows specific environment variables (will not work for Mac and Linux)
+  setup_opendex_docker: `set BRANCH=21.02.11-rc.2&set NETWORK=testnet&${LAUNCHER} setup`,
+  stop_opendex_docker: `set BRANCH=21.02.11-rc.2&set NETWORK=testnet&${LAUNCHER} down`,
 };
 
 const environmentStartedSub = new BehaviorSubject(false);
@@ -78,10 +79,7 @@ const execCommand = (cmd) => {
         );
       });
     } else {
-      // TODO: remove 'testnet'
-      exec(cmd, { env: { NETWORK: "testnet" } }, (error, stdout) =>
-        handleResponse(stdout, error)
-      );
+      exec(cmd, (error, stdout) => handleResponse(stdout, error));
     }
   });
   return cmd$;

--- a/public/ipc.js
+++ b/public/ipc.js
@@ -37,6 +37,7 @@ const AVAILABLE_COMMANDS = {
   wsl_version: "wsl --set-default-version 2",
   start_docker: `"${WINDOWS_DOCKER_EXECUTABLE_PATH}"`,
   // TODO: windows specific environment variables (will not work for Mac and Linux)
+  // TODO: remove testnet
   setup_opendex_docker: `set BRANCH=21.02.11-rc.2&set NETWORK=testnet&${LAUNCHER} setup`,
   stop_opendex_docker: `set BRANCH=21.02.11-rc.2&set NETWORK=testnet&${LAUNCHER} down`,
 };


### PR DESCRIPTION
This commit locks the opendex-docker version to `21.02.11-rc.2`. As a
result the user is not required to manually setup a GitHub access token.